### PR TITLE
ticket#8464-Arreglado el display de dcterms.issued en la vista simple de un item

### DIFF
--- a/src/themes/cicba/app/item-page/simple/field-components/date-metadata-values/cic-date-metadata-values.component.ts
+++ b/src/themes/cicba/app/item-page/simple/field-components/date-metadata-values/cic-date-metadata-values.component.ts
@@ -16,9 +16,9 @@ export class CicDateMetadataValuesComponent extends MetadataValuesComponent impl
   ngOnInit(): void {
       const date = this.mdValues[0].value;
       if (date.length === 10) {
-        this.dateString = new Date(date).toLocaleDateString('es-AR',{ year: 'numeric', month: 'long', day: 'numeric' });
+        this.dateString = new Date(date).toLocaleDateString('es-AR',{ year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
       } else if (date.length === 7) {
-        this.dateString = new Date(date).toLocaleDateString('es-AR',{ year: 'numeric', month: 'long' });
+        this.dateString = new Date(date).toLocaleDateString('es-AR',{ year: 'numeric', month: 'long', timeZone: 'UTC' });
       } else {
         this.dateString = date;
       }


### PR DESCRIPTION
Corregido el display en la vista simple de los ítems, donde antes se mostraba una fecha distinta a la que había en la vista completa del ítem, ahora se muestra la misma.
