### PR TITLE
8253 cambio conformación columnas del home

### DIFF
--- a/src/themes/cicba/app/home-page/home-page.component.scss
+++ b/src/themes/cicba/app/home-page/home-page.component.scss
@@ -21,15 +21,15 @@
 
 .home-main {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     grid-gap: 30px;
 }
 
 .repository-info {
-    grid-column: 1/3;
+    grid-column: 1/4;
     grid-row: 1;
     @media screen and (max-width: map-get($grid-breakpoints, md)) {
-        grid-column: 1/4;
+        grid-column: 1/7;
         grid-row: 1;
     }
 }
@@ -39,19 +39,19 @@
 }
 
 .upload-info {
-    grid-column: 3;
-    grid-row: 1 / 5;
+    grid-column: 4/6;
+    grid-row: 1/5;
     @media screen and (max-width: map-get($grid-breakpoints, md)) {
-        grid-column: 1/4;
+        grid-column: 1/7;
         grid-row: 2;
     }
 }
 
 .last-items-section {
-    grid-column: 1/3;
-    grid-row: 2 / 5;
+    grid-column: 1/4;
+    grid-row: 2/5;
     @media screen and (max-width: map-get($grid-breakpoints, md)) {
-        grid-column: 1/4;
+        grid-column: 1/7;
         grid-row: 3;
     }
 }


### PR DESCRIPTION
Los tres elementos del home (info de cic, el aside y el agregados recientemente) están distribuidos en dos columnas.
Antes, la primera columna ocupaba 2/3 y la segunda 1/3.
Se cambió y ahora la primera columna ocupa 3/5 y la segunda 2/5.
El cambio se aplica también para pantallas de dispositivos móviles y es solo en el home.