### PR TITLE
9557 elimino autoridad de los badges del search

### DIFF
--- a/src/app/shared/search/search.utils.ts
+++ b/src/app/shared/search/search.utils.ts
@@ -16,9 +16,9 @@ export function getFacetValueForType(facetValue: FacetValue, searchFilterConfig:
       return decodeURIComponent(values[1]);
     }
   }
-  if (facetValue.authorityKey) {
-    return addOperatorToFilterValue(facetValue.authorityKey, 'authority');
-  }
+  // if (facetValue.authorityKey) {
+  //   return addOperatorToFilterValue(facetValue.authorityKey, 'authority');
+  // }
 
   return addOperatorToFilterValue(facetValue.value, 'equals');
 }


### PR DESCRIPTION
Comento la línea en la que se pregunta si el filtro tiene autoridad o no, por lo cual lo obligo a buscar siempre por texto (equals). A partir de esto, los badges de filtros aplicados en los resultados de busqueda muestran el label en lugar de la key del authority.