### PR TITLE
9561-Actualizacion, pseudo-cambio de id.

### DIFF
--- a/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
+++ b/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
@@ -22,7 +22,7 @@ export class CicUsageStatsComponent implements OnInit {
             js.src = f;
             js.async = 1;
             fjs.parentNode.insertBefore(js, fjs);
-        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@1.1.2/dist/lrw.js'));
+        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@1.1.5/dist/lrw.js'));
     }
 
     ngOnInit() {
@@ -30,8 +30,10 @@ export class CicUsageStatsComponent implements OnInit {
         if (typeof window['lrw'] === 'function') {
           window['lrw']({
             widget_div_id: 'usage-stats',
-            identifier_prefix: 'oai:digital.cic.gba.gob.ar:11746/',
-            identifier_regex: '\/handle\/[0-9\.]+\/([0-9]+)\/?', // build the identifier from the url
+            //identifier_prefix: 'oai:digital.cic.gba.gob.ar:11746/',
+            //identifier_regex: '\/handle\/[0-9\.]+\/([0-9]+)\/?', // build the identifier from the url
+            //identifier_meta_field: 'citation_abstract_html_url',
+            identifier:  'oai:digital.cic.gba.gob.ar:11746/' ,
             event_labels: {
                 'view': 'Vistas',
                 'download': 'Descargas',

--- a/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
+++ b/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
@@ -17,7 +17,7 @@ export class CicUsageStatsComponent implements OnInit {
     @Input() identifierHandle? : string = '/handle/[0-9.]+/([0-9]+)/?';
     @Input() nodoName! : string;
     @Input() repositoryName! : string;
-    @Input() contryCode! : string;
+    @Input() countryCode! : string;
     @Input() identifierMetaField? : string;
     @Input() nationalSource! : string;
     @Input() repositorySource! : string;
@@ -34,7 +34,7 @@ export class CicUsageStatsComponent implements OnInit {
             js.src = f;
             js.async = 1;
             fjs.parentNode.insertBefore(js, fjs);
-        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@${this.version}/dist/lrw.js'));
+        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@'+this.version+'/dist/lrw.js'));
     }
 
     ngOnInit() {
@@ -45,7 +45,7 @@ export class CicUsageStatsComponent implements OnInit {
             //identifier_prefix: 'oai:digital.cic.gba.gob.ar:11746/',
             //identifier_regex: '\/handle\/[0-9\.]+\/([0-9]+)\/?', // build the identifier from the url
             //identifier_meta_field: 'citation_abstract_html_url',
-            identifier:  '${this.baseIdentifierOAI}:${this.item.handle}' ,
+            identifier:  this.baseIdentifierOAI +':' + this.item.handle ,
             event_labels: {
                 'view': 'Vistas',
                 'download': 'Descargas',
@@ -53,12 +53,12 @@ export class CicUsageStatsComponent implements OnInit {
             },
             scope_labels: {
                 'L': 'LA Referencia',
-                'N': '${this.nodoName}',
-                'R': '${this.repositoryName}'
+                'N': this.nodoName,
+                'R': this.repositoryName
             },
-            country: '${this.countryCode}',
-            national_source: 'SITEID::${this.nationalSource}',
-            repository_source: 'OPENDOAR::${this.repositorySource}'
+            country: this.countryCode,
+            national_source: 'SITEID::' + this.nationalSource ,
+            repository_source: 'OPENDOAR::' + this.repositorySource
           });
         }
       }

--- a/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
+++ b/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Item } from '../../../../../../../app/core/shared/item.model';
 
 /**
  * This component renders the usage-stats badge provided by La Referencia.
@@ -9,6 +10,17 @@ import { Component, OnInit } from '@angular/core';
 })
 
 export class CicUsageStatsComponent implements OnInit {
+   
+    @Input() item!: Item;
+    @Input() version: string = '1.1.5';
+    @Input() baseIdentifierOAI! : string;
+    @Input() identifierHandle? : string = '/handle/[0-9.]+/([0-9]+)/?';
+    @Input() nodoName! : string;
+    @Input() repositoryName! : string;
+    @Input() contryCode! : string;
+    @Input() identifierMetaField? : string;
+    @Input() nationalSource! : string;
+    @Input() repositorySource! : string;
 
     constructor() {
         // script
@@ -22,7 +34,7 @@ export class CicUsageStatsComponent implements OnInit {
             js.src = f;
             js.async = 1;
             fjs.parentNode.insertBefore(js, fjs);
-        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@1.1.5/dist/lrw.js'));
+        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@$this.{version}/dist/lrw.js'));
     }
 
     ngOnInit() {
@@ -33,7 +45,7 @@ export class CicUsageStatsComponent implements OnInit {
             //identifier_prefix: 'oai:digital.cic.gba.gob.ar:11746/',
             //identifier_regex: '\/handle\/[0-9\.]+\/([0-9]+)\/?', // build the identifier from the url
             //identifier_meta_field: 'citation_abstract_html_url',
-            identifier:  'oai:digital.cic.gba.gob.ar:11746/' ,
+            identifier:  '${this.baseIdentifierOAI}:${this.item.handle}' ,
             event_labels: {
                 'view': 'Vistas',
                 'download': 'Descargas',
@@ -41,12 +53,12 @@ export class CicUsageStatsComponent implements OnInit {
             },
             scope_labels: {
                 'L': 'LA Referencia',
-                'N': 'SNRD',
-                'R': 'CIC Digital'
+                'N': '${this.nodoName}',
+                'R': '${this.repositoryName}'
             },
-            country: 'AR',
-            national_source: 'SITEID::132',
-            repository_source: 'OPENDOAR::5634'
+            country: '${this.countryCode}',
+            national_source: 'SITEID::${this.nationalSource}',
+            repository_source: 'OPENDOAR::${this.repositorySource}'
           });
         }
       }

--- a/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
+++ b/src/themes/cicba/app/item-page/simple/field-components/usage-stats/cic-usage-stats.component.ts
@@ -34,7 +34,7 @@ export class CicUsageStatsComponent implements OnInit {
             js.src = f;
             js.async = 1;
             fjs.parentNode.insertBefore(js, fjs);
-        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@$this.{version}/dist/lrw.js'));
+        }(window, document, 'script', 'lrw', 'parameters', 'https://cdn.jsdelivr.net/gh/lareferencia/lrw@${this.version}/dist/lrw.js'));
     }
 
     ngOnInit() {

--- a/src/themes/cicba/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/cicba/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -175,11 +175,11 @@
     </ds-cic-metadata-values>
     <ds-cic-usage-stats
       [version]="'1.1.5'"
-      [baseIdentifierOAI]="'oai:digital.cic.gba.gob.ar:11746'"
+      [baseIdentifierOAI]="'oai:digital.cic.gba.gob.ar'"
       [identifierHandle]="'/handle/[0-9.]+/([0-9]+)/?'"
       [nodoName]="'SNRD'"
       [repositoryName]="'CIC Digital'"
-      [contryCode]="'AR'"
+      [countryCode]="'AR'"
       [nationalSource]="'132'"
       [repositorySource]="'5634'"
       [item]="object">

--- a/src/themes/cicba/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/cicba/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -173,7 +173,17 @@
       [inlineLabel]="true"
       [authorityUrl]="true">
     </ds-cic-metadata-values>
-    <ds-cic-usage-stats></ds-cic-usage-stats>
+    <ds-cic-usage-stats
+      [version]="'1.1.5'"
+      [baseIdentifierOAI]="'oai:digital.cic.gba.gob.ar:11746'"
+      [identifierHandle]="'/handle/[0-9.]+/([0-9]+)/?'"
+      [nodoName]="'SNRD'"
+      [repositoryName]="'CIC Digital'"
+      [contryCode]="'AR'"
+      [nationalSource]="'132'"
+      [repositorySource]="'5634'"
+      [item]="object">
+    </ds-cic-usage-stats>
   </div>
   <div class="abstract-section">
     <ds-cic-metadata-field-wrapper [inlineLabel]="false" [label]="'item.page.abstract' | translate">


### PR DESCRIPTION
Se actualizo la version del widget de la v1.1.2 a la v1.1.5.
Además, para que funcione correctamente, hay que cambiar la forma de recuperar el ID de la página del ítem, ya que con el handle en DSpace 7 no es posible.