### PR TITLE
7565 agrego link a los autores en vista del item

### DIFF
--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.html
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.html
@@ -1,16 +1,9 @@
 <div>
   <!-- Because this template is used by default, we will additionally test for representation type and display accordingly -->
-  <span *ngIf="(mdRepresentation.representationType=='plain_text') && !isLink()" class="dont-break-out">
-    {{mdRepresentation.getValue()}}
-  </span>
-  <a *ngIf="(mdRepresentation.representationType=='plain_text') && isLink()" class="dont-break-out"
-  target="_blank" [href]="mdRepresentation.getValue()">
-    {{mdRepresentation.getValue()}}
-  </a>
-  <span *ngIf="(mdRepresentation.representationType=='authority_controlled')" class="dont-break-out">{{mdRepresentation.getValue()}}</span>
-  <a *ngIf="(mdRepresentation.representationType=='browse_link')"
+  <!-- Hay una única representación porque solo se utiliza para autores de la CIC; si se necesitan nuevas, hay que volver a agregar condicionales  -->
+  <a 
      class="dont-break-out ds-browse-link"
-     [routerLink]="['/browse/', mdRepresentation.browseDefinition.id]"
+     [routerLink]="['/browse/author']"
      [queryParams]="getQueryParams()">
     {{mdRepresentation.getValue()}}
   </a>

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
@@ -22,9 +22,9 @@ export class PlainTextMetadataListElementComponent extends MetadataRepresentatio
    */
   getQueryParams() {
     let queryParams = {startsWith: this.mdRepresentation.getValue()};
-    if (this.mdRepresentation.browseDefinition.getRenderType() === VALUE_LIST_BROWSE_DEFINITION.value) {
-      return {value: this.mdRepresentation.getValue()};
-    }
+    // if (this.mdRepresentation.browseDefinition.getRenderType() === VALUE_LIST_BROWSE_DEFINITION.value) {
+    //   return {value: this.mdRepresentation.getValue()};
+    // }
     return queryParams;
   }
 }


### PR DESCRIPTION
Agrego links a los autores (author, corporate, director, compilator y editor) en la vista del item.
Por la forma en la que se recuperan los autores nunca se accede a la forma de representarlos como link, por eso tuve que comentar algunas líneas que hacían referencia a información que no tenemos y armar el link de manera "estática".